### PR TITLE
feat: make mattermost hook a single parameter

### DIFF
--- a/app/cmd/cmd.go
+++ b/app/cmd/cmd.go
@@ -107,17 +107,12 @@ func (g TelegramGroup) build() (notify.Destination, error) {
 
 // MattermostGroup defines parameters for mattermost hook notifier.
 type MattermostGroup struct {
-	BaseURL string        `long:"base_url" env:"BASE_URL" description:"base url of the mattermost server"`
-	ID      string        `long:"id" env:"ID" description:"id of the hook, where the release notes will be sent"`
+	URL     string        `long:"url" env:"URL" description:"url of the mattermost hook"`
 	Timeout time.Duration `long:"timeout" env:"TIMEOUT" description:"timeout for http requests" default:"5s"`
 }
 
 func (g MattermostGroup) build() (notify.Destination, error) {
-	return notify.NewMattermost(
-		http.Client{Timeout: g.Timeout},
-		g.BaseURL,
-		g.ID,
-	), nil
+	return notify.NewMattermost(http.Client{Timeout: g.Timeout}, g.URL), nil
 }
 
 // PostGroup defines parameters for post notifier.
@@ -166,7 +161,7 @@ func (r *NotifyGroup) Build() (destinations notify.Destinations, err error) {
 }
 
 func (g PostGroup) empty() bool       { return g.URL == "" }
-func (g MattermostGroup) empty() bool { return g.BaseURL == "" || g.ID == "" }
+func (g MattermostGroup) empty() bool { return g.URL == "" }
 func (g TelegramGroup) empty() bool   { return g.ChatID == "" || g.Token == "" }
 func (g GithubNotifierGroup) empty() bool {
 	return g.ReleaseNameTemplate == "" || g.Repo.Owner == "" || g.Repo.Name == ""

--- a/app/notify/mattermost.go
+++ b/app/notify/mattermost.go
@@ -10,31 +10,28 @@ import (
 
 // Mattermost sends messages to Mattermost via webhook.
 type Mattermost struct {
-	cl      *http.Client
-	baseURL string
-	hookID  string
+	cl  *http.Client
+	url string
 }
 
 // NewMattermost makes a new Mattermost notifier.
-func NewMattermost(cl http.Client, baseURL, hookID string) *Mattermost {
-	return &Mattermost{cl: &cl, baseURL: baseURL, hookID: hookID}
+func NewMattermost(cl http.Client, url string) *Mattermost {
+	return &Mattermost{cl: &cl, url: url}
 }
 
 // String returns the name of the notifier.
 func (m *Mattermost) String() string {
-	return fmt.Sprintf("mattermost hook at: %s", m.baseURL)
+	return fmt.Sprintf("mattermost hook at: %s", extractBaseURL(m.url))
 }
 
 // Send sends a message to Mattermost.
 func (m *Mattermost) Send(ctx context.Context, _, text string) error {
-	u := fmt.Sprintf("%s/hooks/%s", m.baseURL, m.hookID)
-
 	b, err := json.Marshal(map[string]string{"text": text})
 	if err != nil {
 		return fmt.Errorf("marshal body: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(b))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, m.url, bytes.NewReader(b))
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}

--- a/app/notify/mattermost_test.go
+++ b/app/notify/mattermost_test.go
@@ -29,7 +29,12 @@ func TestMattermost_Send(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	svc := NewMattermost(*http.DefaultClient, ts.URL, "123")
+	svc := NewMattermost(*http.DefaultClient, ts.URL+"/hooks/123")
 	err := svc.Send(context.Background(), "tag", "release notes")
 	assert.NoError(t, err)
+}
+
+func TestMattermost_String(t *testing.T) {
+	svc := NewMattermost(*http.DefaultClient, "https://example.com/hooks/123")
+	assert.Equal(t, "mattermost hook at: https://example.com", svc.String())
 }

--- a/app/notify/notify.go
+++ b/app/notify/notify.go
@@ -61,3 +61,12 @@ func (d Destinations) Send(ctx context.Context, tagName, text string) error {
 
 	return merr.ErrorOrNil()
 }
+
+func extractBaseURL(url string) string {
+	proto := strings.Split(url, "://")
+	if len(proto) != 2 {
+		return url
+	}
+
+	return proto[0] + "://" + strings.Split(proto[1], "/")[0]
+}

--- a/app/notify/post.go
+++ b/app/notify/post.go
@@ -16,7 +16,7 @@ type Post struct {
 
 // String returns the string representation of the notifier.
 func (p *Post) String() string {
-	return fmt.Sprintf("post to %s", p.URL)
+	return fmt.Sprintf("post to %s", extractBaseURL(p.URL))
 }
 
 // Send sends a POST request to the given URL with release notes.


### PR DESCRIPTION
Use a single parameter to provide mattermost webhook, instead of splitting base url and hook ID.
Return mattermost's base url in `String()`.