### PR TITLE
Duplicated merge commits appear in the diff

### DIFF
--- a/_example/config.yaml
+++ b/_example/config.yaml
@@ -12,7 +12,7 @@ template: |
   ## Release {{ .Date.Format "02.01.2006" }}
   Project: [{{ index .Extras "PROJECT_NAME" }}]({{ index .Extras "PROJECT_URL" }})
   Version: {{.From | substr 0 7}}...{{.To | substr 0 7}}
-  {{- if not .Categories}}- Changes were not endured into pull requests{{end}}
+  {{if not .Categories}}- Changes were not endured into pull requests{{end}}
   
   {{ range .Categories -}}
       {{- .Title }} - {{ len .PRs }} pull requests merged

--- a/app/git/engine/engine.go
+++ b/app/git/engine/engine.go
@@ -10,6 +10,7 @@ import (
 
 const defaultPingTimeout = 1 * time.Minute
 
+//go:generate rm -f mock_interface.go
 //go:generate moq -out mock_interface.go . Interface
 
 // Interface defines methods to retrieve information about repository.
@@ -24,4 +25,6 @@ type Interface interface {
 	ListTags(ctx context.Context) ([]git.Tag, error)
 	// GetLastCommitOfBranch returns the SHA or alias of the last commit in the branch.
 	GetLastCommitOfBranch(ctx context.Context, branch string) (string, error)
+	// GetCommit returns commit by its SHA.
+	GetCommit(ctx context.Context, sha string) (git.Commit, error)
 }

--- a/app/git/engine/github.go
+++ b/app/git/engine/github.go
@@ -128,18 +128,10 @@ func (g *Github) ListTags(ctx context.Context) ([]git.Tag, error) {
 
 type shaGetter interface {
 	GetSHA() string
-	GetStats() *gh.CommitStats
 }
 
 func (g *Github) commitToStore(commitInterface shaGetter) git.Commit {
-	res := git.Commit{
-		SHA: commitInterface.GetSHA(),
-		CommitStats: git.CommitStats{
-			Total:     commitInterface.GetStats().GetTotal(),
-			Additions: commitInterface.GetStats().GetAdditions(),
-			Deletions: commitInterface.GetStats().GetDeletions(),
-		},
-	}
+	res := git.Commit{SHA: commitInterface.GetSHA()}
 	switch cmt := commitInterface.(type) {
 	case *gh.Commit:
 		res.ParentSHAs = lo.Map(cmt.Parents, func(c *gh.Commit, _ int) string { return c.GetSHA() })

--- a/app/git/engine/github.go
+++ b/app/git/engine/github.go
@@ -128,10 +128,18 @@ func (g *Github) ListTags(ctx context.Context) ([]git.Tag, error) {
 
 type shaGetter interface {
 	GetSHA() string
+	GetStats() *gh.CommitStats
 }
 
 func (g *Github) commitToStore(commitInterface shaGetter) git.Commit {
-	res := git.Commit{SHA: commitInterface.GetSHA()}
+	res := git.Commit{
+		SHA: commitInterface.GetSHA(),
+		CommitStats: git.CommitStats{
+			Total:     commitInterface.GetStats().GetTotal(),
+			Additions: commitInterface.GetStats().GetAdditions(),
+			Deletions: commitInterface.GetStats().GetDeletions(),
+		},
+	}
 	switch cmt := commitInterface.(type) {
 	case *gh.Commit:
 		res.ParentSHAs = lo.Map(cmt.Parents, func(c *gh.Commit, _ int) string { return c.GetSHA() })

--- a/app/git/engine/github_test.go
+++ b/app/git/engine/github_test.go
@@ -172,50 +172,6 @@ func TestGithub_ListTags(t *testing.T) {
 	}, tags)
 }
 
-func TestGithub_commitToStore(t *testing.T) {
-	tests := []struct {
-		name   string
-		commit shaGetter
-		want   git.Commit
-	}{
-		{
-			name: "regular commit",
-			commit: &gh.Commit{
-				SHA:     gh.String("sha"),
-				Stats:   &gh.CommitStats{Total: gh.Int(1), Additions: gh.Int(2), Deletions: gh.Int(3)},
-				Parents: []*gh.Commit{{SHA: gh.String("parent1")}, {SHA: gh.String("parent2")}},
-				Message: gh.String("message"),
-			},
-			want: git.Commit{
-				SHA:         "sha",
-				CommitStats: git.CommitStats{Total: 1, Additions: 2, Deletions: 3},
-				ParentSHAs:  []string{"parent1", "parent2"},
-				Message:     "message",
-			},
-		},
-		{
-			name: "repository commit",
-			commit: &gh.RepositoryCommit{
-				SHA:     gh.String("sha"),
-				Stats:   &gh.CommitStats{Total: gh.Int(1), Additions: gh.Int(2), Deletions: gh.Int(3)},
-				Parents: []*gh.Commit{{SHA: gh.String("parent1")}, {SHA: gh.String("parent2")}},
-				Commit:  &gh.Commit{Message: gh.String("message")},
-			},
-			want: git.Commit{
-				SHA:         "sha",
-				CommitStats: git.CommitStats{Total: 1, Additions: 2, Deletions: 3},
-				ParentSHAs:  []string{"parent1", "parent2"},
-				Message:     "message",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, (*Github)(nil).commitToStore(tt.commit))
-		})
-	}
-}
-
 func newGithub(t *testing.T, h http.HandlerFunc) *Github {
 	t.Helper()
 

--- a/app/git/engine/gitlab.go
+++ b/app/git/engine/gitlab.go
@@ -127,10 +127,5 @@ func (g *Gitlab) commitToStore(commit *gl.Commit) git.Commit {
 		SHA:        commit.ID,
 		ParentSHAs: commit.ParentIDs,
 		Message:    commit.Message,
-		CommitStats: git.CommitStats{
-			Total:     commit.Stats.Total,
-			Additions: commit.Stats.Additions,
-			Deletions: commit.Stats.Deletions,
-		},
 	}
 }

--- a/app/git/engine/gitlab.go
+++ b/app/git/engine/gitlab.go
@@ -93,7 +93,9 @@ func (g *Gitlab) ListPRsOfCommit(ctx context.Context, sha string) ([]git.PullReq
 			Labels: lo.Flatten(lo.Map(mr.Labels, func(s string, _ int) []string {
 				return strings.Split(s, ",")
 			})),
-			ClosedAt: lo.FromPtr(mr.ClosedAt),
+			// closed at in MR points to time when MR was closed without merging,
+			// so we use merged at instead.
+			ClosedAt: lo.FromPtr(mr.MergedAt),
 			Branch:   mr.SourceBranch,
 			URL:      mr.WebURL,
 		}

--- a/app/git/engine/gitlab.go
+++ b/app/git/engine/gitlab.go
@@ -124,10 +124,22 @@ func (g *Gitlab) ListTags(ctx context.Context) ([]git.Tag, error) {
 	return res, nil
 }
 
+// GetCommit returns a commit by its SHA.
+func (g *Gitlab) GetCommit(ctx context.Context, sha string) (git.Commit, error) {
+	commit, _, err := g.cl.Commits.GetCommit(g.projectID, sha, gl.WithContext(ctx))
+	if err != nil {
+		return git.Commit{}, fmt.Errorf("do request: %w", err)
+	}
+
+	return g.commitToStore(commit), nil
+}
+
 func (g *Gitlab) commitToStore(commit *gl.Commit) git.Commit {
 	return git.Commit{
-		SHA:        commit.ID,
-		ParentSHAs: commit.ParentIDs,
-		Message:    commit.Message,
+		SHA:         commit.ID,
+		ParentSHAs:  commit.ParentIDs,
+		Message:     commit.Message,
+		CommittedAt: lo.FromPtr(commit.CommittedDate),
+		AuthoredAt:  lo.FromPtr(commit.AuthoredDate),
 	}
 }

--- a/app/git/engine/gitlab.go
+++ b/app/git/engine/gitlab.go
@@ -127,5 +127,10 @@ func (g *Gitlab) commitToStore(commit *gl.Commit) git.Commit {
 		SHA:        commit.ID,
 		ParentSHAs: commit.ParentIDs,
 		Message:    commit.Message,
+		CommitStats: git.CommitStats{
+			Total:     commit.Stats.Total,
+			Additions: commit.Stats.Additions,
+			Deletions: commit.Stats.Deletions,
+		},
 	}
 }

--- a/app/git/engine/gitlab_test.go
+++ b/app/git/engine/gitlab_test.go
@@ -26,8 +26,18 @@ func TestGitlab_Compare(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 
 		err := json.NewEncoder(w).Encode(gl.Compare{Commits: []*gl.Commit{
-			{ID: "sha", Message: "message", ParentIDs: []string{"parent"}},
-			{ID: "sha2", Message: "message2", ParentIDs: []string{"parent2", "parent3"}},
+			{
+				ID:        "sha",
+				Message:   "message",
+				ParentIDs: []string{"parent"},
+				Stats:     &gl.CommitStats{Total: 1, Additions: 1, Deletions: 2},
+			},
+			{
+				ID:        "sha2",
+				Message:   "message2",
+				ParentIDs: []string{"parent2", "parent3"},
+				Stats:     &gl.CommitStats{Total: 1, Additions: 1, Deletions: 2},
+			},
 		}})
 		require.NoError(t, err)
 	})
@@ -38,8 +48,18 @@ func TestGitlab_Compare(t *testing.T) {
 	assert.Equal(t, git.CommitsComparison{
 		TotalCommits: 2,
 		Commits: []git.Commit{
-			{SHA: "sha", Message: "message", ParentSHAs: []string{"parent"}},
-			{SHA: "sha2", Message: "message2", ParentSHAs: []string{"parent2", "parent3"}},
+			{
+				SHA:         "sha",
+				Message:     "message",
+				ParentSHAs:  []string{"parent"},
+				CommitStats: git.CommitStats{Total: 1, Additions: 1, Deletions: 2},
+			},
+			{
+				SHA:         "sha2",
+				Message:     "message2",
+				ParentSHAs:  []string{"parent2", "parent3"},
+				CommitStats: git.CommitStats{Total: 1, Additions: 1, Deletions: 2},
+			},
 		},
 	}, cmp)
 }
@@ -106,6 +126,7 @@ func TestGitlab_ListTags(t *testing.T) {
 				ID:        "sha",
 				ParentIDs: []string{"parent"},
 				Message:   "message",
+				Stats:     &gl.CommitStats{Total: 1, Additions: 1, Deletions: 2},
 			},
 		}})
 		require.NoError(t, err)
@@ -116,9 +137,10 @@ func TestGitlab_ListTags(t *testing.T) {
 	assert.Equal(t, []git.Tag{{
 		Name: "v1.0.0",
 		Commit: git.Commit{
-			SHA:        "sha",
-			ParentSHAs: []string{"parent"},
-			Message:    "message",
+			SHA:         "sha",
+			ParentSHAs:  []string{"parent"},
+			Message:     "message",
+			CommitStats: git.CommitStats{Total: 1, Additions: 1, Deletions: 2},
 		},
 	}}, tags)
 }

--- a/app/git/engine/gitlab_test.go
+++ b/app/git/engine/gitlab_test.go
@@ -123,6 +123,29 @@ func TestGitlab_ListTags(t *testing.T) {
 	}}, tags)
 }
 
+func TestGitlab_GetCommit(t *testing.T) {
+	svc := newGitlab(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v4/projects/projectID/repository/commits/sha", r.URL.Path)
+
+		w.WriteHeader(http.StatusOK)
+
+		err := json.NewEncoder(w).Encode(gl.Commit{
+			ID:        "sha",
+			ParentIDs: []string{"parent"},
+			Message:   "message",
+		})
+		require.NoError(t, err)
+	})
+
+	commit, err := svc.GetCommit(context.Background(), "sha")
+	require.NoError(t, err)
+	assert.Equal(t, git.Commit{
+		SHA:        "sha",
+		ParentSHAs: []string{"parent"},
+		Message:    "message",
+	}, commit)
+}
+
 func newGitlab(t *testing.T, h http.HandlerFunc) *Gitlab {
 	t.Helper()
 

--- a/app/git/engine/gitlab_test.go
+++ b/app/git/engine/gitlab_test.go
@@ -73,7 +73,7 @@ func TestGitlab_ListPRsOfCommit(t *testing.T) {
 			Description:  "description",
 			Author:       &gl.BasicUser{Username: "author"},
 			Labels:       []string{"label1", "label2"},
-			ClosedAt:     lo.ToPtr(now.UTC()),
+			MergedAt:     lo.ToPtr(now.UTC()),
 			SourceBranch: "source",
 			WebURL:       "url",
 		}})

--- a/app/git/engine/gitlab_test.go
+++ b/app/git/engine/gitlab_test.go
@@ -26,18 +26,8 @@ func TestGitlab_Compare(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 
 		err := json.NewEncoder(w).Encode(gl.Compare{Commits: []*gl.Commit{
-			{
-				ID:        "sha",
-				Message:   "message",
-				ParentIDs: []string{"parent"},
-				Stats:     &gl.CommitStats{Total: 1, Additions: 1, Deletions: 2},
-			},
-			{
-				ID:        "sha2",
-				Message:   "message2",
-				ParentIDs: []string{"parent2", "parent3"},
-				Stats:     &gl.CommitStats{Total: 1, Additions: 1, Deletions: 2},
-			},
+			{ID: "sha", Message: "message", ParentIDs: []string{"parent"}},
+			{ID: "sha2", Message: "message2", ParentIDs: []string{"parent2", "parent3"}},
 		}})
 		require.NoError(t, err)
 	})
@@ -48,18 +38,8 @@ func TestGitlab_Compare(t *testing.T) {
 	assert.Equal(t, git.CommitsComparison{
 		TotalCommits: 2,
 		Commits: []git.Commit{
-			{
-				SHA:         "sha",
-				Message:     "message",
-				ParentSHAs:  []string{"parent"},
-				CommitStats: git.CommitStats{Total: 1, Additions: 1, Deletions: 2},
-			},
-			{
-				SHA:         "sha2",
-				Message:     "message2",
-				ParentSHAs:  []string{"parent2", "parent3"},
-				CommitStats: git.CommitStats{Total: 1, Additions: 1, Deletions: 2},
-			},
+			{SHA: "sha", Message: "message", ParentSHAs: []string{"parent"}},
+			{SHA: "sha2", Message: "message2", ParentSHAs: []string{"parent2", "parent3"}},
 		},
 	}, cmp)
 }
@@ -126,7 +106,6 @@ func TestGitlab_ListTags(t *testing.T) {
 				ID:        "sha",
 				ParentIDs: []string{"parent"},
 				Message:   "message",
-				Stats:     &gl.CommitStats{Total: 1, Additions: 1, Deletions: 2},
 			},
 		}})
 		require.NoError(t, err)
@@ -137,10 +116,9 @@ func TestGitlab_ListTags(t *testing.T) {
 	assert.Equal(t, []git.Tag{{
 		Name: "v1.0.0",
 		Commit: git.Commit{
-			SHA:         "sha",
-			ParentSHAs:  []string{"parent"},
-			Message:     "message",
-			CommitStats: git.CommitStats{Total: 1, Additions: 1, Deletions: 2},
+			SHA:        "sha",
+			ParentSHAs: []string{"parent"},
+			Message:    "message",
 		},
 	}}, tags)
 }

--- a/app/git/engine/mock_interface.go
+++ b/app/git/engine/mock_interface.go
@@ -22,6 +22,9 @@ var _ Interface = &InterfaceMock{}
 // 			CompareFunc: func(ctx context.Context, fromSHA string, toSHA string) (git.CommitsComparison, error) {
 // 				panic("mock out the Compare method")
 // 			},
+// 			GetCommitFunc: func(ctx context.Context, sha string) (git.Commit, error) {
+// 				panic("mock out the GetCommit method")
+// 			},
 // 			GetLastCommitOfBranchFunc: func(ctx context.Context, branch string) (string, error) {
 // 				panic("mock out the GetLastCommitOfBranch method")
 // 			},
@@ -40,6 +43,9 @@ var _ Interface = &InterfaceMock{}
 type InterfaceMock struct {
 	// CompareFunc mocks the Compare method.
 	CompareFunc func(ctx context.Context, fromSHA string, toSHA string) (git.CommitsComparison, error)
+
+	// GetCommitFunc mocks the GetCommit method.
+	GetCommitFunc func(ctx context.Context, sha string) (git.Commit, error)
 
 	// GetLastCommitOfBranchFunc mocks the GetLastCommitOfBranch method.
 	GetLastCommitOfBranchFunc func(ctx context.Context, branch string) (string, error)
@@ -60,6 +66,13 @@ type InterfaceMock struct {
 			FromSHA string
 			// ToSHA is the toSHA argument value.
 			ToSHA string
+		}
+		// GetCommit holds details about calls to the GetCommit method.
+		GetCommit []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Sha is the sha argument value.
+			Sha string
 		}
 		// GetLastCommitOfBranch holds details about calls to the GetLastCommitOfBranch method.
 		GetLastCommitOfBranch []struct {
@@ -82,6 +95,7 @@ type InterfaceMock struct {
 		}
 	}
 	lockCompare               sync.RWMutex
+	lockGetCommit             sync.RWMutex
 	lockGetLastCommitOfBranch sync.RWMutex
 	lockListPRsOfCommit       sync.RWMutex
 	lockListTags              sync.RWMutex
@@ -123,6 +137,41 @@ func (mock *InterfaceMock) CompareCalls() []struct {
 	mock.lockCompare.RLock()
 	calls = mock.calls.Compare
 	mock.lockCompare.RUnlock()
+	return calls
+}
+
+// GetCommit calls GetCommitFunc.
+func (mock *InterfaceMock) GetCommit(ctx context.Context, sha string) (git.Commit, error) {
+	if mock.GetCommitFunc == nil {
+		panic("InterfaceMock.GetCommitFunc: method is nil but Interface.GetCommit was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		Sha string
+	}{
+		Ctx: ctx,
+		Sha: sha,
+	}
+	mock.lockGetCommit.Lock()
+	mock.calls.GetCommit = append(mock.calls.GetCommit, callInfo)
+	mock.lockGetCommit.Unlock()
+	return mock.GetCommitFunc(ctx, sha)
+}
+
+// GetCommitCalls gets all the calls that were made to GetCommit.
+// Check the length with:
+//     len(mockedInterface.GetCommitCalls())
+func (mock *InterfaceMock) GetCommitCalls() []struct {
+	Ctx context.Context
+	Sha string
+} {
+	var calls []struct {
+		Ctx context.Context
+		Sha string
+	}
+	mock.lockGetCommit.RLock()
+	calls = mock.calls.GetCommit
+	mock.lockGetCommit.RUnlock()
 	return calls
 }
 

--- a/app/git/git.go
+++ b/app/git/git.go
@@ -31,9 +31,11 @@ type User struct {
 
 // Commit represents a repository commit.
 type Commit struct {
-	SHA        string
-	ParentSHAs []string
-	Message    string
+	SHA         string
+	ParentSHAs  []string
+	Message     string
+	CommittedAt time.Time
+	AuthoredAt  time.Time
 }
 
 // CommitsComparison is the result of comparing two commits.

--- a/app/git/git.go
+++ b/app/git/git.go
@@ -33,6 +33,15 @@ type Commit struct {
 	SHA        string
 	ParentSHAs []string
 	Message    string
+
+	CommitStats
+}
+
+// CommitStats represents a commit stats.
+type CommitStats struct {
+	Total     int
+	Additions int
+	Deletions int
 }
 
 // CommitsComparison is the result of comparing two commits.

--- a/app/git/git.go
+++ b/app/git/git.go
@@ -33,15 +33,6 @@ type Commit struct {
 	SHA        string
 	ParentSHAs []string
 	Message    string
-
-	CommitStats
-}
-
-// CommitStats represents a commit stats.
-type CommitStats struct {
-	Total     int
-	Additions int
-	Deletions int
 }
 
 // CommitsComparison is the result of comparing two commits.

--- a/app/git/git.go
+++ b/app/git/git.go
@@ -12,14 +12,15 @@ type Changelog struct {
 // PullRequest represents a pull/merge request from the
 // remote repository.
 type PullRequest struct {
-	Number   int       `yaml:"number"`
-	Title    string    `yaml:"title"`
-	Body     string    `yaml:"body"`
-	Author   User      `yaml:"author"`
-	Labels   []string  `yaml:"labels"`
-	ClosedAt time.Time `yaml:"closed_at"`
-	Branch   string    `yaml:"branch"`
-	URL      string    `yaml:"url"`
+	Number         int       `yaml:"number"`
+	Title          string    `yaml:"title"`
+	Body           string    `yaml:"body"`
+	Author         User      `yaml:"author"`
+	Labels         []string  `yaml:"labels"`
+	ClosedAt       time.Time `yaml:"closed_at"`
+	Branch         string    `yaml:"branch"`
+	URL            string    `yaml:"url"`
+	ReceivedBySHAs []string  `yaml:"received_by_shas"`
 }
 
 // User holds user data.

--- a/app/service/notes/notes.go
+++ b/app/service/notes/notes.go
@@ -81,12 +81,13 @@ func (s *Builder) Build(req BuildRequest) (string, error) {
 			if hasAnyOfLabels || hasBranchPrefix {
 				usedPRs[i] = true
 				categoryData.PRs = append(categoryData.PRs, prTmplData{
-					Number:   pr.Number,
-					Title:    pr.Title,
-					Author:   pr.Author.Username,
-					ClosedAt: pr.ClosedAt,
-					URL:      pr.URL,
-					Branch:   pr.Branch,
+					Number:         pr.Number,
+					Title:          pr.Title,
+					Author:         pr.Author.Username,
+					ClosedAt:       pr.ClosedAt,
+					URL:            pr.URL,
+					Branch:         pr.Branch,
+					ReceivedBySHAs: pr.ReceivedBySHAs,
 				})
 			}
 		}
@@ -185,10 +186,11 @@ type categoryTmplData struct {
 }
 
 type prTmplData struct {
-	Number   int
-	Title    string
-	Author   string
-	URL      string
-	Branch   string
-	ClosedAt time.Time
+	Number         int
+	Title          string
+	Author         string
+	URL            string
+	Branch         string
+	ClosedAt       time.Time
+	ReceivedBySHAs []string
 }

--- a/app/service/notes/notes.go
+++ b/app/service/notes/notes.go
@@ -125,12 +125,13 @@ func (s *Builder) makeUnlabeledCategory(used []bool, prs []git.PullRequest) cate
 		}
 
 		category.PRs = append(category.PRs, prTmplData{
-			Number:   pr.Number,
-			Title:    pr.Title,
-			Author:   pr.Author.Username,
-			URL:      pr.URL,
-			ClosedAt: pr.ClosedAt,
-			Branch:   pr.Branch,
+			Number:         pr.Number,
+			Title:          pr.Title,
+			Author:         pr.Author.Username,
+			URL:            pr.URL,
+			ClosedAt:       pr.ClosedAt,
+			Branch:         pr.Branch,
+			ReceivedBySHAs: pr.ReceivedBySHAs,
 		})
 	}
 

--- a/app/service/service.go
+++ b/app/service/service.go
@@ -58,6 +58,11 @@ func (s *Service) closedPRsBetweenSHA(ctx context.Context, fromSHA, toSHA string
 	}
 
 	for _, commit := range commits.Commits {
+		// probably a duplicated merge commit
+		if commit.Additions == 0 && commit.Deletions == 0 {
+			continue
+		}
+
 		refCommitSHA, ok := s.isMergeCommit(commit)
 		if !ok {
 			continue

--- a/app/service/service.go
+++ b/app/service/service.go
@@ -58,11 +58,6 @@ func (s *Service) closedPRsBetweenSHA(ctx context.Context, fromSHA, toSHA string
 	}
 
 	for _, commit := range commits.Commits {
-		// probably a duplicated merge commit
-		if commit.Additions == 0 && commit.Deletions == 0 {
-			continue
-		}
-
 		refCommitSHA, ok := s.isMergeCommit(commit)
 		if !ok {
 			continue

--- a/app/service/service_test.go
+++ b/app/service/service_test.go
@@ -52,30 +52,11 @@ func TestService_Changelog(t *testing.T) {
 				CompareFunc: func(ctx context.Context, from, to string) (git.CommitsComparison, error) {
 					return git.CommitsComparison{
 						Commits: []git.Commit{
-							{
-								SHA:         "from",
-								ParentSHAs:  []string{"parent", "pr1"},
-								Message:     "Pull request #1",
-								CommitStats: git.CommitStats{Additions: 1, Deletions: 1},
-							},
-							// this won't be picked up, because of the zero diff
-							{
-								SHA:        "intermediate",
-								ParentSHAs: []string{"from", "to"},
-								Message:    "intermediate commit message",
-							},
-							{
-								SHA:         "intermediate_squashed",
-								ParentSHAs:  []string{"intermediate"},
-								Message:     "squash: Pull request #4",
-								CommitStats: git.CommitStats{Additions: 1, Deletions: 1},
-							},
-							{
-								SHA:         "to",
-								ParentSHAs:  []string{"intermediate", "pr2"},
-								Message:     "Pull request #2",
-								CommitStats: git.CommitStats{Additions: 1, Deletions: 1},
-							},
+							{SHA: "from", ParentSHAs: []string{"parent", "pr1"}, Message: "Pull request #1"},
+							// this won't be picked up
+							{SHA: "intermediate", ParentSHAs: []string{"from"}, Message: "intermediate commit message"},
+							{SHA: "intermediate_squashed", ParentSHAs: []string{"intermediate"}, Message: "squash: Pull request #4"},
+							{SHA: "to", ParentSHAs: []string{"intermediate", "pr2"}, Message: "Pull request #2"},
 						},
 						TotalCommits: 4,
 					}, nil

--- a/app/service/service_test.go
+++ b/app/service/service_test.go
@@ -23,6 +23,9 @@ func TestService_Changelog(t *testing.T) {
 		compareCalledErr := errors.New("compare called")
 		svc := &Service{
 			Engine: &engine.InterfaceMock{
+				GetCommitFunc: func(ctx context.Context, sha string) (git.Commit, error) {
+					return git.Commit{SHA: "sha"}, nil
+				},
 				GetLastCommitOfBranchFunc: func(ctx context.Context, branch string) (string, error) {
 					assert.Equal(t, "master", branch)
 					return "sha", nil
@@ -49,6 +52,9 @@ func TestService_Changelog(t *testing.T) {
 		svc := &Service{
 			SquashCommitMessageRx: regexp.MustCompile(`^squash: (.*)$`),
 			Engine: &engine.InterfaceMock{
+				GetCommitFunc: func(ctx context.Context, sha string) (git.Commit, error) {
+					return git.Commit{SHA: "from", ParentSHAs: []string{"parent", "pr1"}, Message: "Pull request #1"}, nil
+				},
 				CompareFunc: func(ctx context.Context, from, to string) (git.CommitsComparison, error) {
 					return git.CommitsComparison{
 						Commits: []git.Commit{

--- a/app/service/service_test.go
+++ b/app/service/service_test.go
@@ -52,11 +52,30 @@ func TestService_Changelog(t *testing.T) {
 				CompareFunc: func(ctx context.Context, from, to string) (git.CommitsComparison, error) {
 					return git.CommitsComparison{
 						Commits: []git.Commit{
-							{SHA: "from", ParentSHAs: []string{"parent", "pr1"}, Message: "Pull request #1"},
-							// this won't be picked up
-							{SHA: "intermediate", ParentSHAs: []string{"from"}, Message: "intermediate commit message"},
-							{SHA: "intermediate_squashed", ParentSHAs: []string{"intermediate"}, Message: "squash: Pull request #4"},
-							{SHA: "to", ParentSHAs: []string{"intermediate", "pr2"}, Message: "Pull request #2"},
+							{
+								SHA:         "from",
+								ParentSHAs:  []string{"parent", "pr1"},
+								Message:     "Pull request #1",
+								CommitStats: git.CommitStats{Additions: 1, Deletions: 1},
+							},
+							// this won't be picked up, because of the zero diff
+							{
+								SHA:        "intermediate",
+								ParentSHAs: []string{"from", "to"},
+								Message:    "intermediate commit message",
+							},
+							{
+								SHA:         "intermediate_squashed",
+								ParentSHAs:  []string{"intermediate"},
+								Message:     "squash: Pull request #4",
+								CommitStats: git.CommitStats{Additions: 1, Deletions: 1},
+							},
+							{
+								SHA:         "to",
+								ParentSHAs:  []string{"intermediate", "pr2"},
+								Message:     "Pull request #2",
+								CommitStats: git.CommitStats{Additions: 1, Deletions: 1},
+							},
 						},
 						TotalCommits: 4,
 					}, nil


### PR DESCRIPTION
It appears that when someone is resolving merge conflicts by merging master branch into the feature branch, merge commits, that has been appeared in the previous releases.

Example of such situation:
```
*  (HEAD -> main) Merge branch 'b2'
|\
| * (b2) 7
| * 6
* |  5 (merge)
|\ \
| |/
|/|
| * (b1) 4
| *  2
* |  3
|/
* 1
```

The solution is to check the timestamp of the commit, that is being observed for the presence of PR, for being later than the "from" commit.