### PR TITLE
fix: request pull requests from engine on the current commit, not parent

### DIFF
--- a/app/git/engine/engine.go
+++ b/app/git/engine/engine.go
@@ -25,6 +25,4 @@ type Interface interface {
 	ListTags(ctx context.Context) ([]git.Tag, error)
 	// GetLastCommitOfBranch returns the SHA or alias of the last commit in the branch.
 	GetLastCommitOfBranch(ctx context.Context, branch string) (string, error)
-	// GetCommit returns commit by its SHA.
-	GetCommit(ctx context.Context, sha string) (git.Commit, error)
 }

--- a/app/git/engine/github.go
+++ b/app/git/engine/github.go
@@ -127,16 +127,6 @@ func (g *Github) ListTags(ctx context.Context) ([]git.Tag, error) {
 	return res, nil
 }
 
-// GetCommit returns commit by the given SHA.
-func (g *Github) GetCommit(ctx context.Context, sha string) (git.Commit, error) {
-	commit, _, err := g.cl.Repositories.GetCommit(ctx, g.owner, g.name, sha)
-	if err != nil {
-		return git.Commit{}, fmt.Errorf("get commit: %w", err)
-	}
-
-	return g.commitToStore(commit), nil
-}
-
 type shaGetter interface {
 	GetSHA() string
 }

--- a/app/git/engine/github_test.go
+++ b/app/git/engine/github_test.go
@@ -176,28 +176,6 @@ func TestGithub_ListTags(t *testing.T) {
 	}, tags)
 }
 
-func TestGithub_GetCommit(t *testing.T) {
-	svc := newGithub(t, func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/repos/owner/name/commits/sha", r.URL.Path, "path is not set")
-
-		err := json.NewEncoder(w).Encode(&gh.RepositoryCommit{
-			SHA:     gh.String("sha 1"),
-			Parents: []*gh.Commit{{SHA: gh.String("parent 1")}},
-			Commit:  &gh.Commit{Message: gh.String("message 1")},
-		})
-		require.NoError(t, err)
-		w.WriteHeader(http.StatusOK)
-	})
-
-	commit, err := svc.GetCommit(context.Background(), "sha")
-	require.NoError(t, err)
-	assert.Equal(t, git.Commit{
-		SHA:        "sha 1",
-		ParentSHAs: []string{"parent 1"},
-		Message:    "message 1",
-	}, commit)
-}
-
 func newGithub(t *testing.T, h http.HandlerFunc) *Github {
 	t.Helper()
 

--- a/app/git/engine/gitlab.go
+++ b/app/git/engine/gitlab.go
@@ -125,16 +125,6 @@ func (g *Gitlab) ListTags(ctx context.Context) ([]git.Tag, error) {
 	return res, nil
 }
 
-// GetCommit returns a commit by its SHA.
-func (g *Gitlab) GetCommit(ctx context.Context, sha string) (git.Commit, error) {
-	commit, _, err := g.cl.Commits.GetCommit(g.projectID, sha, gl.WithContext(ctx))
-	if err != nil {
-		return git.Commit{}, fmt.Errorf("do request: %w", err)
-	}
-
-	return g.commitToStore(commit), nil
-}
-
 func (g *Gitlab) commitToStore(commit *gl.Commit) git.Commit {
 	return git.Commit{
 		SHA:         commit.ID,

--- a/app/git/engine/gitlab_test.go
+++ b/app/git/engine/gitlab_test.go
@@ -125,29 +125,6 @@ func TestGitlab_ListTags(t *testing.T) {
 	}}, tags)
 }
 
-func TestGitlab_GetCommit(t *testing.T) {
-	svc := newGitlab(t, func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/v4/projects/projectID/repository/commits/sha", r.URL.Path)
-
-		w.WriteHeader(http.StatusOK)
-
-		err := json.NewEncoder(w).Encode(gl.Commit{
-			ID:        "sha",
-			ParentIDs: []string{"parent"},
-			Message:   "message",
-		})
-		require.NoError(t, err)
-	})
-
-	commit, err := svc.GetCommit(context.Background(), "sha")
-	require.NoError(t, err)
-	assert.Equal(t, git.Commit{
-		SHA:        "sha",
-		ParentSHAs: []string{"parent"},
-		Message:    "message",
-	}, commit)
-}
-
 func newGitlab(t *testing.T, h http.HandlerFunc) *Gitlab {
 	t.Helper()
 

--- a/app/git/engine/mock_interface.go
+++ b/app/git/engine/mock_interface.go
@@ -22,9 +22,6 @@ var _ Interface = &InterfaceMock{}
 // 			CompareFunc: func(ctx context.Context, fromSHA string, toSHA string) (git.CommitsComparison, error) {
 // 				panic("mock out the Compare method")
 // 			},
-// 			GetCommitFunc: func(ctx context.Context, sha string) (git.Commit, error) {
-// 				panic("mock out the GetCommit method")
-// 			},
 // 			GetLastCommitOfBranchFunc: func(ctx context.Context, branch string) (string, error) {
 // 				panic("mock out the GetLastCommitOfBranch method")
 // 			},
@@ -43,9 +40,6 @@ var _ Interface = &InterfaceMock{}
 type InterfaceMock struct {
 	// CompareFunc mocks the Compare method.
 	CompareFunc func(ctx context.Context, fromSHA string, toSHA string) (git.CommitsComparison, error)
-
-	// GetCommitFunc mocks the GetCommit method.
-	GetCommitFunc func(ctx context.Context, sha string) (git.Commit, error)
 
 	// GetLastCommitOfBranchFunc mocks the GetLastCommitOfBranch method.
 	GetLastCommitOfBranchFunc func(ctx context.Context, branch string) (string, error)
@@ -66,13 +60,6 @@ type InterfaceMock struct {
 			FromSHA string
 			// ToSHA is the toSHA argument value.
 			ToSHA string
-		}
-		// GetCommit holds details about calls to the GetCommit method.
-		GetCommit []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// Sha is the sha argument value.
-			Sha string
 		}
 		// GetLastCommitOfBranch holds details about calls to the GetLastCommitOfBranch method.
 		GetLastCommitOfBranch []struct {
@@ -95,7 +82,6 @@ type InterfaceMock struct {
 		}
 	}
 	lockCompare               sync.RWMutex
-	lockGetCommit             sync.RWMutex
 	lockGetLastCommitOfBranch sync.RWMutex
 	lockListPRsOfCommit       sync.RWMutex
 	lockListTags              sync.RWMutex
@@ -137,41 +123,6 @@ func (mock *InterfaceMock) CompareCalls() []struct {
 	mock.lockCompare.RLock()
 	calls = mock.calls.Compare
 	mock.lockCompare.RUnlock()
-	return calls
-}
-
-// GetCommit calls GetCommitFunc.
-func (mock *InterfaceMock) GetCommit(ctx context.Context, sha string) (git.Commit, error) {
-	if mock.GetCommitFunc == nil {
-		panic("InterfaceMock.GetCommitFunc: method is nil but Interface.GetCommit was just called")
-	}
-	callInfo := struct {
-		Ctx context.Context
-		Sha string
-	}{
-		Ctx: ctx,
-		Sha: sha,
-	}
-	mock.lockGetCommit.Lock()
-	mock.calls.GetCommit = append(mock.calls.GetCommit, callInfo)
-	mock.lockGetCommit.Unlock()
-	return mock.GetCommitFunc(ctx, sha)
-}
-
-// GetCommitCalls gets all the calls that were made to GetCommit.
-// Check the length with:
-//     len(mockedInterface.GetCommitCalls())
-func (mock *InterfaceMock) GetCommitCalls() []struct {
-	Ctx context.Context
-	Sha string
-} {
-	var calls []struct {
-		Ctx context.Context
-		Sha string
-	}
-	mock.lockGetCommit.RLock()
-	calls = mock.calls.GetCommit
-	mock.lockGetCommit.RUnlock()
 	return calls
 }
 

--- a/app/git/git.go
+++ b/app/git/git.go
@@ -3,12 +3,6 @@ package git
 
 import "time"
 
-// Changelog represents a basic changelog.
-type Changelog struct {
-	TagName   string
-	ClosedPRs []PullRequest
-}
-
 // PullRequest represents a pull/merge request from the
 // remote repository.
 type PullRequest struct {

--- a/app/service/service_test.go
+++ b/app/service/service_test.go
@@ -23,9 +23,6 @@ func TestService_Changelog(t *testing.T) {
 		compareCalledErr := errors.New("compare called")
 		svc := &Service{
 			Engine: &engine.InterfaceMock{
-				GetCommitFunc: func(ctx context.Context, sha string) (git.Commit, error) {
-					return git.Commit{SHA: "sha"}, nil
-				},
 				GetLastCommitOfBranchFunc: func(ctx context.Context, branch string) (string, error) {
 					assert.Equal(t, "master", branch)
 					return "sha", nil
@@ -52,9 +49,6 @@ func TestService_Changelog(t *testing.T) {
 		svc := &Service{
 			SquashCommitMessageRx: regexp.MustCompile(`^squash: (.*)$`),
 			Engine: &engine.InterfaceMock{
-				GetCommitFunc: func(ctx context.Context, sha string) (git.Commit, error) {
-					return git.Commit{SHA: "from", ParentSHAs: []string{"parent", "pr1"}, Message: "Pull request #1"}, nil
-				},
 				CompareFunc: func(ctx context.Context, from, to string) (git.CommitsComparison, error) {
 					return git.CommitsComparison{
 						Commits: []git.Commit{
@@ -69,13 +63,13 @@ func TestService_Changelog(t *testing.T) {
 				},
 				ListPRsOfCommitFunc: func(ctx context.Context, sha string) ([]git.PullRequest, error) {
 					switch sha {
-					case "pr1":
+					case "from":
 						return []git.PullRequest{
 							{Number: 1, Title: "Pull request #1", SourceBranch: "feature/1", ClosedAt: now},
 							{Number: 2, Title: "Pull request #2", Labels: []string{"bug"}, ClosedAt: now},
 							{Number: 3, Title: "Pull request #3"},
 						}, nil
-					case "pr2":
+					case "to":
 						return []git.PullRequest{
 							{Number: 2, Title: "Pull request #2", Labels: []string{"bug"}, ClosedAt: now},
 							{Number: 3, Title: "Pull request #5", Labels: []string{"ignore"}},


### PR DESCRIPTION
honestly I have no idea why I have requested on parents before

this should fix the problem of reappearing of PRs, that were closed in previous releases in current release